### PR TITLE
Add encoding=utf-8 when opening a file

### DIFF
--- a/chrhyme/data_prep.py
+++ b/chrhyme/data_prep.py
@@ -32,7 +32,7 @@ with open('data/chengyu.txt', 'r', encoding='gb18030') as f:
 print('+ 成语词典 (含俗语)：', len(vocab))
 
 
-with open('data/dict.txt', 'r') as f:
+with open('data/dict.txt', 'r', encoding="utf-8") as f:
     for line in f:
         word = line.strip().split()[0]
         if len(word) > 1 and re.match(r'^[\u4E00-\u9FA5，]+$', word):
@@ -58,7 +58,7 @@ for word in vocab:
     if len(word) > 3 and word[-4] != '，':
         look_up[tuple([pinyin[1][-1] for pinyin in pinyins[-4:]])].append(word)
 
-with open('phrase_dict.txt', 'w') as f:
+with open('phrase_dict.txt', 'w', encoding="utf-8") as f:
     for k, v in look_up.items():
         f.write('{}\t{}\n'.format(' '.join(list(k)), ' '.join(sorted(v))))
     print('done!')

--- a/chrhyme/ryhthm_generator.py
+++ b/chrhyme/ryhthm_generator.py
@@ -8,7 +8,7 @@ from typing import Set, List, Dict
 from chrhyme.parser import word_parser
 
 phrase_dict = {}
-with open(rf('chrhyme', 'data/phrase_dict.txt'), 'r') as f:
+with open(rf('chrhyme', 'data/phrase_dict.txt'), 'r', encoding="utf-8") as f:
     for line in f:
         items = line.strip().split('\t')
         phrase_dict[tuple(items[0].split())] = items[1].split()

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author="Jiajie Yan",
     author_email="jiaeyan@gmail.com",
     description="Find rhymes for Chinese words.",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type='text/markdown',
     license="MIT",
     url="https://github.com/jiaeyan/Chinese-Rhyme",


### PR DESCRIPTION
Without this flag, the package can't be installed (setup.py) or run on Windows.

Because Python will open a file by GBK codec on Windows if there it is not set to utf-8.